### PR TITLE
Fix deprecations for new dbt engine compatibility

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -5,9 +5,9 @@ require-dbt-version: [">=1.3.0", "<2.0.0"]
 models:
   amplitude_source:
     +schema: _source_amplitude
-    materialized: table
+    +materialized: table
     tmp:
-      materialized: view
+      +materialized: view
 vars:
   amplitude_source:
     event: "{{ source('amplitude', 'event') }}"


### PR DESCRIPTION
This is a PR raised to fix [dbt config deprecations](https://github.com/dbt-labs/dbt-core/discussions/11493) currently in the package and improve compatibility with the new dbt engine being released on 5/28 at the dbt Launch Showcase.

Ideally, this PR would need to be merged and a new version of the package should be published to the Hub before 5/28.

Please comment on this PR if you have any question.